### PR TITLE
Improve serial port detection

### DIFF
--- a/Pi/GUI.py
+++ b/Pi/GUI.py
@@ -168,7 +168,7 @@ def open_serial_ports(serial_ports):
 def serialWrite(*args):
     """ Writes to serial ports in list. """
     logWrite("Function call - serial write: " + str(*args))
-    for s in serial_ports:
+    for s in SERIAL_PORTS:
         try:
             s.write(str.encode(*args))
         except (OSError, serial.SerialException) as e:

--- a/Pi/GUI.py
+++ b/Pi/GUI.py
@@ -78,7 +78,7 @@ def remove_tty_device(name_to_remove):
         for x in range(len(OPEN_SERIAL_PORTS)-1):
             if name_to_remove in str(OPEN_SERIAL_PORTS[x]):
                 idx_to_remove = x
-        del OPEN_SERIAL_PORTS[x]
+        del OPEN_SERIAL_PORT[idx_to_remove]
         log_str = "Removed %s." % name_to_remove
         logWrite(log_str)
         print(log_str)

--- a/Pi/GUI.py
+++ b/Pi/GUI.py
@@ -78,7 +78,7 @@ def remove_tty_device(name_to_remove):
         for x in range(len(OPEN_SERIAL_PORTS)-1):
             if name_to_remove in str(OPEN_SERIAL_PORTS[x]):
                 idx_to_remove = x
-        del OPEN_SERIAL_PORT[idx_to_remove]
+        del OPEN_SERIAL_PORTS[idx_to_remove]
         log_str = "Removed %s." % name_to_remove
         logWrite(log_str)
         print(log_str)

--- a/Pi/GUI.py
+++ b/Pi/GUI.py
@@ -77,7 +77,8 @@ def remove_tty_device(name_to_remove):
         SERIAL_PORTS.remove(name_to_remove)
         for x in range(len(OPEN_SERIAL_PORTS)-1):
             if name_to_remove in str(OPEN_SERIAL_PORTS[x]):
-                del OPEN_SERIAL_PORTS[x]
+                idx_to_remove = x
+        del OPEN_SERIAL_PORTS[idx_to_remove]
         log_str = "Removed %s." % name_to_remove
         logWrite(log_str)
         print(log_str)

--- a/Pi/GUI.py
+++ b/Pi/GUI.py
@@ -75,13 +75,15 @@ def remove_tty_device(name_to_remove):
     global SERIAL_PORTS, OPEN_SERIAL_PORTS
     try:
         SERIAL_PORTS.remove(name_to_remove)
-        for x in range(len(OPEN_SERIAL_PORTS)-1):
+        idx_to_remove = -1
+        for x in range(len(OPEN_SERIAL_PORTS)):
             if name_to_remove in str(OPEN_SERIAL_PORTS[x]):
                 idx_to_remove = x
-        del OPEN_SERIAL_PORTS[idx_to_remove]
-        log_str = "Removed %s." % name_to_remove
-        logWrite(log_str)
-        print(log_str)
+        if idx_to_remove != -1:
+            del OPEN_SERIAL_PORTS[idx_to_remove]
+            log_str = "Removed %s." % name_to_remove
+            logWrite(log_str)
+            print(log_str)
     except ValueError:
         # Not printing anything because it sometimes tries too many times and is irrelevant
         pass

--- a/Pi/GUI.py
+++ b/Pi/GUI.py
@@ -77,8 +77,7 @@ def remove_tty_device(name_to_remove):
         SERIAL_PORTS.remove(name_to_remove)
         for x in range(len(OPEN_SERIAL_PORTS)-1):
             if name_to_remove in str(OPEN_SERIAL_PORTS[x]):
-                idx_to_remove = x
-        del OPEN_SERIAL_PORTS[idx_to_remove]
+                del OPEN_SERIAL_PORTS[x]
         log_str = "Removed %s." % name_to_remove
         logWrite(log_str)
         print(log_str)

--- a/Pi/config.json
+++ b/Pi/config.json
@@ -1,0 +1,11 @@
+{
+    "arduino": {
+        "serial_ports" : [
+            "/dev/ttyACM0",
+            "/dev/ttyACM1",
+            "/dev/ttyACM2",
+            "/dev/ttyACM3"
+        ]
+    }
+}
+


### PR DESCRIPTION
Fixes #192 .

Changes proposed in this request:
- Adds and gives user a command line option to use config.json to specify serial ports with default devices expected
- If not using config.json, uses pyudev to automatically detect adding and removing Arduinos (this is the default option)
- Does not enforce having 4 serial ports to open; uses the serial port count for arduino_count
- Adds some constants at the top of GUI.py and adds some docstrings
- Adds some writes to logFile but also adds some prints to the screen for serial ports
- Tries to be better about using all caps for globals

@ISS-Mimic
