### PR TITLE
one 'PVCU 2A BGA POS' is actually 'PVCU 3A BGA POS'

### DIFF
--- a/docs/dashboard.html
+++ b/docs/dashboard.html
@@ -737,7 +737,7 @@
   <div class="val" id="S4000007">NO DATA</div>
 </div>
 <div class="SPARTAN pui" title="Photovolatic Control Unit (PVCU) - Solar Array - 3A - Beta Gimble Assembly (BGA) Position (degrees)">
-  <div class="desc">PVCU 2A BGA POS</div>
+  <div class="desc">PVCU 3A BGA POS</div>
   <div class="val" id="S4000008">NO DATA</div>
 </div>
 <div class="SPARTAN pui" title="Photovolatic Control Unit (PVCU) - Solar Array - 3B - Drive Voltage">


### PR DESCRIPTION
Fixes a typo. :)

@ISS-Mimic
