### PR TITLE
Fixed crew screen issues closes #700

### DIFF
--- a/Pi/Screens/Crew_Screen.kv
+++ b/Pi/Screens/Crew_Screen.kv
@@ -1,13 +1,13 @@
 <Crew_Screen>:
     name: 'crew'
-    
+
     FloatLayout:
         # Background
         #Image:
         #    id: Crew_background
         #    source: f'{root.mimic_directory}/Mimic/Pi/imgs/crew/CrewBackground.png'
         #    fit_mode: "fill"
-        
+
         # Top Left - Expedition Title
         Label:
             id: expedition_title
@@ -17,7 +17,7 @@
             color: 0, 1, 0, 1  # Bright green
             font_size: dp(40)
             bold: True
-        
+
         # Top Center - Expedition Duration Timer
         Label:
             id: expedition_duration_label
@@ -27,7 +27,7 @@
             color: 1, 1, 1, 1
             font_size: dp(16)
             bold: True
-        
+
         Label:
             id: expedition_duration_timer
             pos_hint: {"center_x": 0.5, "center_y": 0.86}
@@ -37,7 +37,7 @@
             font_size: dp(24)
             bold: True
             halign: 'center'
-        
+
         # Top Right - ISS Continuously Crewed Time
         Label:
             id: iss_crewed_time_label
@@ -47,7 +47,7 @@
             color: 1, 1, 1, 1
             font_size: dp(16)
             bold: True
-        
+
         Label:
             id: ISS_crewed_years
             pos_hint: {"center_x": 0.73, "center_y": 0.86}
@@ -56,7 +56,7 @@
             color: 1, 1, 1, 1
             font_size: dp(24)
             bold: True
-        
+
         Label:
             id: ISS_crewed_months
             pos_hint: {"center_x": 0.83, "center_y": 0.86}
@@ -65,7 +65,7 @@
             color: 1, 1, 1, 1
             font_size: dp(24)
             bold: True
-        
+
         Label:
             id: ISS_crewed_days
             pos_hint: {"center_x": 0.93, "center_y": 0.86}
@@ -74,7 +74,7 @@
             color: 1, 1, 1, 1
             font_size: dp(24)
             bold: True
-        
+
         # Time format labels
         Label:
             pos_hint: {"center_x": 0.73, "center_y": 0.82}
@@ -82,21 +82,21 @@
             markup: True
             color: 1, 1, 1, 1
             font_size: dp(12)
-        
+
         Label:
             pos_hint: {"center_x": 0.83, "center_y": 0.82}
             text: 'Months'
             markup: True
             color: 1, 1, 1, 1
             font_size: dp(12)
-        
+
         Label:
             pos_hint: {"center_x": 0.93, "center_y": 0.82}
             text: 'Days'
             markup: True
             color: 1, 1, 1, 1
             font_size: dp(12)
-        
+
         # Total People on the ISS
         Label:
             id: total_crew_count_label
@@ -106,7 +106,7 @@
             color: 1, 1, 1, 1
             font_size: dp(14)
             bold: True
-        
+
         Label:
             id: total_crew_count
             pos_hint: {"center_x": 0.93, "center_y": 0.78}
@@ -115,7 +115,7 @@
             color: 0, 1, 0, 1
             font_size: dp(14)
             bold: True
-        
+
         Label:
             id: loading
             pos_hint: {"center_x": 0.35, "center_y": 0.5}
@@ -129,7 +129,7 @@
         ScrollView:
             pos_hint: {"center_x": 0.35, "center_y": 0.5}
             size_hint: 0.65, 0.6
-            
+
             GridLayout:
                 id: crew_container
                 cols: 3
@@ -138,7 +138,7 @@
                 size_hint_y: None
                 height: self.minimum_height
                 # Crew widgets will be added here dynamically
-        
+
         # Right Side - Expedition Mission Patch
         Image:
             id: expedition_patch
@@ -146,46 +146,48 @@
             size_hint: 0.25, 0.25
             source: f'{root.mimic_directory}/Mimic/Pi/imgs/crew/Expedition_Patch.png'
             fit_mode: "scale-down"
-        
+
         # Crewed Vehicles List
         ScrollView:
             pos_hint: {"center_x": 0.83, "center_y": 0.35}
-            size_hint: 0.25, 0.3
-            
+            size_hint: 0.35, 0.35
+
             GridLayout:
                 id: crewed_vehicles_container
                 cols: 1
                 spacing: dp(2)
                 padding: dp(0)
+                size_hint_x: None
                 size_hint_y: None
                 height: self.minimum_height
+                width: self.parent.width
                 # Crewed vehicle widgets will be added here dynamically
-        
+
         # Legend
         BoxLayout:
             pos_hint: {"center_x": 0.35, "center_y": 0.18}
             size_hint: 0.65, 0.1
             orientation: 'horizontal'
             spacing: dp(10)
-            
+
             Label:
                 text: 'CMDR = Commander'
                 color: 1, 1, 1, 1
                 font_size: dp(12)
                 bold: True
-            
+
             Label:
                 text: 'FE = Flight Engineer'
                 color: 1, 1, 1, 1
                 font_size: dp(12)
                 bold: True
-            
+
             Label:
                 text: 'Credit: spacefacts.de'
                 color: 1, 1, 1, 1
                 font_size: dp(12)
                 bold: True
-        
+
        # ---------- STATUS DISPLAY (Bottom Rectangle) ----------
         Label:
             id: status_label
@@ -198,7 +200,7 @@
             halign: 'center'
             valign: 'middle'
             pos_hint: {"center_x": 0.57, "center_y": 0.07}
-        
+
         # ---------- BOTTOM TOOLBAR ----------
         Image:
             id: signal
@@ -208,7 +210,7 @@
             anim_loop: 0
             fit_mode: "scale-down"
             pos_hint: {"center_x": 0.05, "center_y": 0.07}
-        
+
         Image:
             id: arduino
             source: f"{root.mimic_directory}/Mimic/Pi/imgs/signal/arduino_offline.png"
@@ -217,7 +219,7 @@
             anim_loop: -1
             fit_mode: "scale-down"
             pos_hint: {"center_x": 0.14, "center_y": 0.08}
-        
+
         Label:
             id: arduino_count
             pos_hint: {"center_x": 0.14, "center_y": 0.08}
@@ -226,7 +228,7 @@
             color: 1, 1, 1, 1
             font_size: self.height * 1
             size_hint: 0.06, 0.08
-        
+
         # ─────────────────────── Navigation ────────────────────────────────
 
         Button:
@@ -245,13 +247,13 @@
         Rectangle:
             pos: self.pos
             size: self.size
-    
+
     orientation: 'vertical'
     size_hint_y: None
     height: dp(200)
     padding: dp(10)
     spacing: dp(2)
-    
+
     # Crew Member Photo
     AsyncImage:
         id: crew_photo
@@ -262,7 +264,7 @@
         allow_stretch: False
         keep_ratio: True
         nocache: True  # Force reload when source changes
-    
+
     # Crew Member Name
     Label:
         text: root.name
@@ -270,14 +272,14 @@
         font_size: dp(16)
         bold: True
         size_hint_y: 0.2
-    
+
     # Country
     Label:
         text: root.country
         color: 0.8, 0.8, 0.8, 1
         font_size: dp(12)
         size_hint_y: 0.15
-    
+
     # Role (Commander/Flight Engineer)
     Label:
         text: root.role
@@ -285,14 +287,14 @@
         font_size: dp(14)
         bold: True
         size_hint_y: 0.15
-    
+
     # Mission Days / Total Days in Space
     Label:
         text: f"Mission: {root.mission_days} days\nTotal: {root.total_days} days"
         color: 1, 1, 1, 1
         font_size: dp(12)
         size_hint_y: 0.2
-    
+
     # Spacecraft Info
     Label:
         text: root.spacecraft

--- a/Pi/checkCrew.py
+++ b/Pi/checkCrew.py
@@ -82,8 +82,8 @@ def fetch_spacefacts_crew(max_attempts: int = 3, timeout: int = 10) -> List[Dict
             # Look for the crew table with the specific structure
             for table in tables:
                 table_text = str(table)
-                if ('No.' in table_text and 'Nation' in table_text and 'Surname' in table_text and 
-                    'Given names' in table_text and 'Position' in table_text):
+                headers = ['No.', 'Nation', 'Surname', 'Given names', 'Position']
+                if all(any(h in cell.get_text() for cell in table.find_all(['td', 'th'])) for h in headers):
                     crew_table = table
                     break
             
@@ -99,7 +99,7 @@ def fetch_spacefacts_crew(max_attempts: int = 3, timeout: int = 10) -> List[Dict
             for row_index, row in enumerate(rows):
                 cells = row.find_all(['td', 'th'])
                 # Skip rows that don't have enough data or are header rows
-                if len(cells) < 13:  # Need at least 13 columns for complete crew data
+                if len(cells) < 12:  # Need at least 12 columns for complete crew data
                     continue
                 
                 # Check if this row contains crew data (should have a number in first cell)
@@ -107,6 +107,7 @@ def fetch_spacefacts_crew(max_attempts: int = 3, timeout: int = 10) -> List[Dict
                 # Look for crew number pattern (1, 2, 3, etc.)
                 if not first_cell.isdigit():
                     continue
+
                 
                 try:
                     # Extract country from flag image
@@ -203,7 +204,6 @@ def fetch_spacefacts_crew(max_attempts: int = 3, timeout: int = 10) -> List[Dict
                                 
                                 # Also fetch mission data for total time in space calculation
                                 mission_data = get_astronaut_mission_data(astronaut_page_url)
-                                #print(mission_data)
                             else:
                                 image_url = None
                                 mission_data = {'total_time_in_space': 0, 'current_mission_duration': 0}
@@ -219,7 +219,8 @@ def fetch_spacefacts_crew(max_attempts: int = 3, timeout: int = 10) -> List[Dict
                         'landing_date': cells[9].get_text(strip=True),  # Landing date
                         'landing_time': cells[10].get_text(strip=True),  # Landing time
                         'mission_duration': '',  # Will be calculated by crew screen based on launch time
-                        'orbits': cells[12].get_text(strip=True),  # Orbits
+                        #'orbits': cells[12].get_text(strip=True),  # Orbits - removed from webpage
+                        'orbits': None,
                         'expedition': f"Expedition {expedition_number}",  # Use expedition number found at start
                         'image_url': image_url,  # URL to astronaut's personal page with image
                         'total_time_in_space': mission_data['total_time_in_space'],  # Total lifetime days in space


### PR DESCRIPTION
Fixes #700

Changes proposed in this request:
- fixes errors on crew screen data fetching
- spacefacts.de removed a column from the html table, breaking everything
- removed all VV DB dependency for crew screen

@ISS-Mimic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes broken crew screen by adapting to Spacefacts.de changes and removing the VV DB dependency.
> 
> - Replace VV DB usage: build `crewed_vehicles` from `current_crew` by grouping on `spaceship` and using earliest `launch_date`; update total crew from `crew_data` length
> - Harden Spacefacts scraping: robust header detection, expect 12 columns, drop `orbits`, improve image/mission data extraction; keep schema and snapshot flow
> - UI tweaks: enlarge `crewed_vehicles` panel (`size_hint` 0.35,0.35) and make container fill width; vehicle item shows `spacecraft` and `(arrival)` with larger font
> - Keep checksum-based refresh; minor logging/cleanup
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af4ca8a505741b709aeb1d2bd159661462dbc76f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->